### PR TITLE
Fixed the shady opacity chaqnge mechanism for the subtitle header

### DIFF
--- a/frontend/src/animations/homeAnimations.ts
+++ b/frontend/src/animations/homeAnimations.ts
@@ -50,17 +50,6 @@ export const runHeaderScrollTimeline = (numbers: CSSNumbers = cssNumbers) => {
       end: `+=${numbers.animation.scrollEnd}`,
       pin: true,
       scrub: numbers.animation.scrubDuration,
-      onUpdate: (self) => {
-        const scrollY = self.scroll();
-        const end = self.end;
-
-        const color = scrollY >= end ? "white" : "black";
-        gsap.to(".subtitle-header", {
-          color,
-          duration: numbers.animation.colorChangeDuration,
-          ease: numbers.animation.eases.power1Out
-        });
-      },
     },
   })
     .add("syncPoint") // 🔑 all tweens anchor here
@@ -71,6 +60,11 @@ export const runHeaderScrollTimeline = (numbers: CSSNumbers = cssNumbers) => {
       opacity: 0,
       ease: numbers.animation.eases.power1In,
     }, "syncPoint")
+    .to(".subtitle-header", {
+      color: "white",
+      duration: numbers.animation.colorChangeDuration,
+      ease: numbers.animation.eases.power1Out
+    }, "sync-point")
     .to(".header", {
       backgroundColor: "white",
       ease: numbers.animation.eases.power1In,


### PR DESCRIPTION
Replace the ad-hoc onUpdate opacity hack in runHeaderScrollTimeline with a ScrollTrigger-driven approach where the subtitle’s opacity is controlled by the child triggers’ progress. This makes the effect deterministic, scrub-friendly, and easier to reason about.

link: https://nanofydp.atlassian.net/browse/OC-22