### PR TITLE
fix: prevent unwanted text breaks

### DIFF
--- a/frontend/src/components/TextBox.tsx
+++ b/frontend/src/components/TextBox.tsx
@@ -57,8 +57,8 @@ export const TextBox = forRef<HTMLDivElement, TextBoxProps>(
           textAlign: "left",
           border: cssNumbers.testing.border,
           minWidth: 0,
-          wordWrap: "break-word",
-          wordBreak: "keep-all",
+          overflowWrap: "break-word",
+          wordBreak: "normal",
           ...styleContent,
         }}
       >


### PR DESCRIPTION
## Summary
- ensure TextBox content wraps normally by default

## Testing
- `pnpm --filter frontend lint`
- `pnpm --filter frontend vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68bcd131d55c8326a46345f1742002c2